### PR TITLE
correct matching attachement to handle more cases.

### DIFF
--- a/l10n_ch_bank_statement_import_postfinance/models/postfinance_file_parser.py
+++ b/l10n_ch_bank_statement_import_postfinance/models/postfinance_file_parser.py
@@ -187,9 +187,8 @@ class XMLPFParser(object):
                 '//ns:Stmt/ns:Ntry/ns:AcctSvcrRef/text()',
                 namespaces={'ns': ns})
             for transaction in transaction_nodes:
-                att_name = self.file_name + '-' + transaction
-                # Attachment files are limited to 87 char names
-                att = self.attachments.get(att_name[:87])
+                att_name = self.file_name + '-' + transaction[:23]
+                att = self.attachments.get(att_name)
                 if att:
                     attachments.append((transaction, att))
         return attachments


### PR DESCRIPTION
I'm not sure about a char name limit to 87, 
But AcctSvrcRef is shorted from 9 char. (or only the 23 first char) 