### PR TITLE
comply with pain008 standard

### DIFF
--- a/l10n_ch_pain_direct_debit/models/account_payment_order.py
+++ b/l10n_ch_pain_direct_debit/models/account_payment_order.py
@@ -223,7 +223,11 @@ class AccountPaymentOrder(models.Model):
                 partner_bank.bank_id.clearing.zfill(5)
             ccp_other = etree.SubElement(party_agent_institution, 'Othr')
             ccp_other_id = etree.SubElement(ccp_other, 'Id')
-            ccp_other_id.text = self.company_partner_bank_id.l10n_ch_postal
+            ref_subparts = self.company_partner_bank_id.l10n_ch_postal.split('-')
+            ccp_other_id.text = (
+                ref_subparts[0] + ref_subparts[1].rjust(6, '0') + ref_subparts[2]
+            )
+
             res = True
         else:
             res = super(AccountPaymentOrder, self).generate_party_agent(


### PR DESCRIPTION

According to [Six payment standard for direct debit](https://www.six-group.com/dam/download/banking-services/interbank-clearing/fr/standardization/iso/swiss-recommendations/implementation-guidelines-swiss-dd.pdf), (p23) postal account should not be with - only numbers

![image](https://user-images.githubusercontent.com/8391661/85407090-0811de80-b563-11ea-884c-474d54538839.png)
