### PR TITLE
CO-3370 Fix automatic bank import with CRON or 'import FDS file' button

### DIFF
--- a/l10n_ch_fds_import_bank_statement/models/fds_postfinance_file.py
+++ b/l10n_ch_fds_import_bank_statement/models/fds_postfinance_file.py
@@ -8,6 +8,12 @@ from odoo.exceptions import Warning as UserError
 _logger = logging.getLogger(__name__)
 
 
+class NoStatementsError(UserError):
+    def __init__(self, message):
+        self.name = message
+        self.message = message
+
+
 class FdsPostfinanceFile(models.Model):
     _inherit = 'fds.postfinance.file'
 
@@ -52,17 +58,16 @@ class FdsPostfinanceFile(models.Model):
             })
             _logger.info("[OK] import file '%s' to bank Statements",
                          self.filename)
+        except NoStatementsError as e:
+            _logger.info(e.name, self.filename)
+            self.write({
+                'state': 'done',
+                'error_message': e.name or e.args and e.args[0]
+            })
         except UserError as e:
             # wrong parser used, raise the error to the parent so it's not
             # catch by the following except Exception
-            if e.name == _('This file doesn\'t contain any statement.'):
-                _logger.info(e.name, self.filename)
-                self.write({
-                    'state': 'done',
-                    'error_message': e.name or e.args and e.args[0]
-                })
-            else:
-                raise e
+            raise e
         except Exception as e:
             self.env.cr.rollback()
             self.invalidate_cache()

--- a/l10n_ch_fds_import_bank_statement/models/fds_postfinance_file.py
+++ b/l10n_ch_fds_import_bank_statement/models/fds_postfinance_file.py
@@ -1,10 +1,9 @@
 # © 2015 Compassion CH (Nicolas Tran)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
 import logging
 from odoo.exceptions import Warning as UserError
-from odoo.addons.l10n_ch_payment_return_sepa.models.errors import NoStatementsError
 
 _logger = logging.getLogger(__name__)
 
@@ -56,13 +55,14 @@ class FdsPostfinanceFile(models.Model):
         except UserError as e:
             # wrong parser used, raise the error to the parent so it's not
             # catch by the following except Exception
-            raise e
-        except NoStatementsError as e:
-            _logger.info(e.name, self.filename)
-            self.write({
-                'state': 'done',
-                'error_message': e.name or e.args and e.args[0]
-            })
+            if e.name == _('This file doesn\'t contain any statement.'):
+                _logger.info(e.name, self.filename)
+                self.write({
+                    'state': 'done',
+                    'error_message': e.name or e.args and e.args[0]
+                })
+            else:
+                raise e
         except Exception as e:
             self.env.cr.rollback()
             self.invalidate_cache()

--- a/l10n_ch_fds_import_bank_statement/models/fds_postfinance_file.py
+++ b/l10n_ch_fds_import_bank_statement/models/fds_postfinance_file.py
@@ -4,6 +4,7 @@
 from odoo import models, fields, api
 import logging
 from odoo.exceptions import Warning as UserError
+from odoo.addons.l10n_ch_payment_return_sepa.models.errors import NoStatementsError
 
 _logger = logging.getLogger(__name__)
 
@@ -56,6 +57,12 @@ class FdsPostfinanceFile(models.Model):
             # wrong parser used, raise the error to the parent so it's not
             # catch by the following except Exception
             raise e
+        except NoStatementsError as e:
+            _logger.info(e.name, self.filename)
+            self.write({
+                'state': 'done',
+                'error_message': e.name or e.args and e.args[0]
+            })
         except Exception as e:
             self.env.cr.rollback()
             self.invalidate_cache()

--- a/l10n_ch_fds_postfinance/wizards/fds_files_import_from_fds_wizard.py
+++ b/l10n_ch_fds_postfinance/wizards/fds_files_import_from_fds_wizard.py
@@ -110,6 +110,8 @@ class FdsFilesImportFromFDSWizard(models.TransientModel):
             # process the files (done by the childrens of this module)
             for file in fds_files_ids:
                 self.process_files(file)
+                # We save the file if correctly processed
+                self.env.cr.commit()
 
             self.state = 'done'
         except:

--- a/l10n_ch_fds_upload_sepa/models/fds_postfinance_file.py
+++ b/l10n_ch_fds_upload_sepa/models/fds_postfinance_file.py
@@ -61,7 +61,7 @@ class FdsPostfinanceFile(models.Model):
             except ValueError:
                 # wrong parser used, we ignore this line since it will need
                 # to be parsed later on
-                pass
+                continue
             except Exception as e:
                 self.env.cr.rollback()
                 self.env.clear()

--- a/l10n_ch_fds_upload_sepa/models/fds_postfinance_file.py
+++ b/l10n_ch_fds_upload_sepa/models/fds_postfinance_file.py
@@ -58,6 +58,10 @@ class FdsPostfinanceFile(models.Model):
                                  pf_file.filename)
 
                     pain_files += pf_file
+            except ValueError:
+                # wrong parser used, we ignore this line since it will need
+                # to be parsed later on
+                pass
             except Exception as e:
                 self.env.cr.rollback()
                 self.env.clear()
@@ -71,7 +75,7 @@ class FdsPostfinanceFile(models.Model):
                     # pylint: disable=invalid-commit
                     self.env.cr.commit()
                 _logger.error("[FAIL] import file '%s' as pain 000",
-                              (pf_file.filename), exc_info=True)
+                              pf_file.filename, exc_info=True)
 
         return super(FdsPostfinanceFile,
                      self - pain_files).import_to_bank_statements()

--- a/l10n_ch_payment_return_sepa/models/errors.py
+++ b/l10n_ch_payment_return_sepa/models/errors.py
@@ -8,6 +8,12 @@ class NoTransactionsError(except_orm):
         self.object = obj
 
 
+class NoStatementsError(except_orm):
+    def __init__(self, message):
+        self.name = message
+        self.message = message
+
+
 class NoPaymentReturnError(except_orm):
     def __init__(self, message):
         self.name = message

--- a/l10n_ch_payment_return_sepa/models/errors.py
+++ b/l10n_ch_payment_return_sepa/models/errors.py
@@ -8,12 +8,6 @@ class NoTransactionsError(except_orm):
         self.object = obj
 
 
-class NoStatementsError(except_orm):
-    def __init__(self, message):
-        self.name = message
-        self.message = message
-
-
 class NoPaymentReturnError(except_orm):
     def __init__(self, message):
         self.name = message


### PR DESCRIPTION
There were multiple issues with the automated import of FDS files:
- Sometimes, if an import failed, mutliple files would fail even though manually importing them would work without any error.
- The import of an FDS file without any statement in it would fail even though it should trivially work.
- When some import failed, the error message contained in it would not correspond to the actual error.
This PR provides solution to address all three of these issues. To solve the first issue, we _commit_ the transaction for every file instead in all cases. Previously, when some file would fail, a _rollback_ would occur, losing all processing information for other files. The second one has been addressed by handling an error specifically. The third one required to bypass the error writing for a specific error: it is an error that is expected to happen in most cases (if the file is not of type pain.002), so we don't want to write the error so early (the program will try to use other parsers on it later on).