### PR TITLE
[T2750] FIX: The due date is no longer calculated based on the curren…

### DIFF
--- a/ebill_postfinance/models/ebill_postfinance_invoice_message.py
+++ b/ebill_postfinance/models/ebill_postfinance_invoice_message.py
@@ -237,7 +237,8 @@ class EbillPostfinanceInvoiceMessage(models.Model):
         date_due = None
         if self.invoice_id.invoice_payment_term_id:
             terms = self.invoice_id.invoice_payment_term_id.compute(
-                self.invoice_id.amount_total
+                value=self.invoice_id.amount_total,
+                date_ref=self.invoice_id.invoice_date,
             )
             if terms:
                 # Returns all payment and their date like [('2020-12-07', 430.37), ...]

--- a/ebill_postfinance/models/ebill_postfinance_invoice_message.py
+++ b/ebill_postfinance/models/ebill_postfinance_invoice_message.py
@@ -313,7 +313,7 @@ class EbillPostfinanceInvoiceMessage(models.Model):
         if self.invoice_id.invoice_payment_term_id:
             terms = self.invoice_id.invoice_payment_term_id.compute(
                 value=self.invoice_id.amount_total,
-                date_ref=self.invoice_id.invoice_date
+                date_ref=self.invoice_id.invoice_date,
             )
             if terms:
                 # Get the last payment date

--- a/ebill_postfinance/models/ebill_postfinance_invoice_message.py
+++ b/ebill_postfinance/models/ebill_postfinance_invoice_message.py
@@ -312,7 +312,8 @@ class EbillPostfinanceInvoiceMessage(models.Model):
         date_due = None
         if self.invoice_id.invoice_payment_term_id:
             terms = self.invoice_id.invoice_payment_term_id.compute(
-                self.invoice_id.amount_total
+                value=self.invoice_id.amount_total,
+                date_ref=self.invoice_id.invoice_date
             )
             if terms:
                 # Get the last payment date


### PR DESCRIPTION
There was a problem with invoices payable via ebill (postfinance). It is possible to specify the invoice date and the due date in the form.

However, the due date is either calculated (e.g. 10 nets days from the invoice date) or clearly defined (30/11/2025).

In the first case, the compute function calculated the due date from the current date. It did not take into consideration the invoice date specified in the Odoo invoice form.