### PR TITLE
[T3316] FIX : LSV/DD debit order validation

### DIFF
--- a/l10n_ch_pain_direct_debit/models/account_payment_order.py
+++ b/l10n_ch_pain_direct_debit/models/account_payment_order.py
@@ -351,7 +351,7 @@ class AccountPaymentOrder(models.Model):
             )
             instruction_identification.text = self._prepare_field(
                 "Intruction Identification",
-                "str(line.move_id.id)",
+                "str(line.id)",
                 {"line": line},
                 35,
                 gen_args=gen_args,
@@ -361,7 +361,7 @@ class AccountPaymentOrder(models.Model):
             )
             end2end_identification.text = self._prepare_field(
                 "End to End Identification",
-                "str(line.move_id.id)",
+                "str(line.id)",
                 {"line": line},
                 35,
                 gen_args=gen_args,
@@ -376,7 +376,7 @@ class AccountPaymentOrder(models.Model):
             instructed_amount = etree.SubElement(
                 dd_transaction_info, "InstdAmt", Ccy=currency_name
             )
-            instructed_amount.text = f"{line.move_id.amount_total:.2f}"
+            instructed_amount.text = f"{line.amount:.2f}"
 
             # .../  <DbtrAgt>
             ori_debtor_agent = etree.SubElement(dd_transaction_info, "DbtrAgt")
@@ -553,7 +553,7 @@ class AccountPaymentOrder(models.Model):
 
         # It sets the check sum, <CtrlSum>
         ctrl_sum = float_round(
-            sum(payment.move_id.amount_total for payment in self.payment_ids), 2
+            sum(payment.amount for payment in self.payment_ids), 2
         )
         control_sum_a.text = str(ctrl_sum)
 

--- a/l10n_ch_pain_direct_debit/models/account_payment_order.py
+++ b/l10n_ch_pain_direct_debit/models/account_payment_order.py
@@ -552,9 +552,7 @@ class AccountPaymentOrder(models.Model):
         nb_of_transactions_a.text = str(len(self.payment_ids))
 
         # It sets the check sum, <CtrlSum>
-        ctrl_sum = float_round(
-            sum(payment.amount for payment in self.payment_ids), 2
-        )
+        ctrl_sum = float_round(sum(payment.amount for payment in self.payment_ids), 2)
         control_sum_a.text = str(ctrl_sum)
 
         return self.finalize_sepa_file_creation(xml_root, gen_args)


### PR DESCRIPTION
## Goal

Fix Swiss Direct Debit and LSV payment file generation and schema validation errors in Odoo 18. Ensure generated `pain.008` XML files comply with official SIX Interbank Clearing standard (`pain.008.001.02.ch.03.xsd`) and resolve validation failures caused by legacy field reference behaviors.

## Technical Aspects

* **Amount Calculation Fixes:** Updated `InstdAmt` (Instruction Amount) and `CtrlSum` (Control Sum) logic in `l10n_ch_pain_direct_debit/models/account_payment_order.py`.
* **Odoo 18 Compatibility:** Replaced legacy field references `move_id`.
* **Schema Validation:** Verified generated XML payloads pass local and official SIX Interbank Clearing XSD schema validation tests.

## MISC

### Observation: "Error on Send" in Local Development
During local testing of QT-0001 for Direct Debit, payment orders generate valid XML files but transition to `output_error_on_send` with the following traceback:
```text
File ".../fs_storage/models/fs_storage.py", line 611, in fs
    self.ensure_one()
ValueError: Expected singleton: fs.storage()
```

**Root Cause**: The local development database lacks an attached fs.storage record on EDI Backend `#3` (edi_storage_oca handler).

**Impact**: This is strictly an environment configuration artifact affecting automated file transport/storage in local development environment. The underlying XML payload (pain.008) is complete and valid, and this step should be resolved automatically in staging/production environments where active storage backends are configured.